### PR TITLE
Rename dynafake to dynamock

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI](https://github.com/foxygoat/dynafake/workflows/ci/badge.svg?branch=master)
 [![Godoc](https://img.shields.io/badge/godoc-ref-blue)](https://pkg.go.dev/foxygo.at/dynafake)
-[![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://app.slack.com/client/T029RQSE6/C011LKH21HC)
+[![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://gophers.slack.com/app_redirect?channel=foxygoat)
 
 File-based
 [DynamoDB](https://pkg.go.dev/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Dynafake
 
-![CI](https://github.com/foxygoat/dynafake/workflows/ci/badge.svg?branch=master)
-[![Godoc](https://img.shields.io/badge/godoc-ref-blue)](https://pkg.go.dev/foxygo.at/dynafake)
+![CI](https://github.com/foxygoat/dynamock/workflows/ci/badge.svg?branch=master)
+[![Godoc](https://img.shields.io/badge/godoc-ref-blue)](https://pkg.go.dev/foxygo.at/dynamock)
 [![Slack chat](https://img.shields.io/badge/slack-gophers-795679?logo=slack)](https://gophers.slack.com/app_redirect?channel=foxygoat)
 
 File-based

--- a/dynafake.go
+++ b/dynafake.go
@@ -1,11 +1,11 @@
-// Package dynafake provides a file-based dynamoDB fake called DB.
+// Package dynamock provides a file-based dynamoDB fake called DB.
 //
 // DB implements the dynamodbiface.DynamoDBAPI interface.
 // Use it for testing, local development and execution.
 // Dynamodb docs:
 //   https://pkg.go.dev/github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface
 //   https://pkg.go.dev/github.com/aws/aws-sdk-go/service/dynamodb
-package dynafake
+package dynamock
 
 // DB implements the dynamodbiface.DynamoDBAPI interface
 type DB struct {

--- a/dynafake_test.go
+++ b/dynafake_test.go
@@ -1,4 +1,4 @@
-package dynafake
+package dynamock
 
 import (
 	"context"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module foxygo.at/dynafake
+module foxygo.at/dynamock
 
 go 1.14
 

--- a/unimplemented.go
+++ b/unimplemented.go
@@ -1,4 +1,4 @@
-package dynafake
+package dynamock
 
 import (
 	"fmt"


### PR DESCRIPTION
Rename dynafake to dynamock, because it is becoming increasingly clear that
mocking  is required of this package as well and it more clearly hints at
DynamoDB as opposed to other Dyna* software services such as Dynatrace.

Housekeeping: update Slack link on README.md slack badge to:
   https://gophers.slack.com/app_redirect?channel=foxygoat